### PR TITLE
Copy final fields in builder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,8 @@
                     <compilerArguments>
                         <extdirs>${project.build.directory}/dependency/IntelliJ-IDEA-CE/idea-IC-133.331/lib/</extdirs>
                     </compilerArguments>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/jetbrains/plugins/innerbuilder/GenerateInnerBuilderHandler.java
+++ b/src/main/java/org/jetbrains/plugins/innerbuilder/GenerateInnerBuilderHandler.java
@@ -169,7 +169,7 @@ public class GenerateInnerBuilderHandler implements LanguageCodeInsightActionHan
                     }
 
                     for (PsiFieldMember member : fieldMembers) {
-                        if (member.getElement().getModifierList().hasModifierProperty(PsiModifier.FINAL) && newBuilderMethod) continue;
+                        if (member.getElement().getModifierList().hasModifierProperty(PsiModifier.FINAL) && !finalSetters) continue;
                         if (newBuilderMethod) copyConstructorText.append("builder.");
                         copyConstructorText.append(member.getElement().getName()).append("= copy.").append(member.getElement().getName()).append(";");
                     }

--- a/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderAction.java
+++ b/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderAction.java
@@ -2,14 +2,9 @@ package org.jetbrains.plugins.innerbuilder;
 
 import com.intellij.codeInsight.CodeInsightActionHandler;
 import com.intellij.codeInsight.actions.BaseCodeInsightAction;
-import com.intellij.lang.Language;
-import com.intellij.lang.LanguageCodeInsightActionHandler;
-import com.intellij.lang.LanguageExtension;
-import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
-import com.intellij.psi.util.PsiUtilBase;
 import org.jetbrains.annotations.NotNull;
 
 /**


### PR DESCRIPTION
I noticed that final fields weren't available in the copy builder even if "Generate builder methods for final fields" was checked. I think this change fixes that.

I also had to switch to a release version of the download-maven-plugin in order to get the build to work.
