### PR TITLE
Use field names as setter parameter names

### DIFF
--- a/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderGenerator.java
+++ b/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderGenerator.java
@@ -298,7 +298,9 @@ public class InnerBuilderGenerator implements Runnable {
             methodName = fieldName;
         }
 
-        final String parameterName = !BUILDER_SETTER_DEFAULT_PARAMETER_NAME.equals(fieldName) ?
+        final String parameterName = options.contains(InnerBuilderOption.FIELD_NAMES) ? 
+                fieldNames :
+                !BUILDER_SETTER_DEFAULT_PARAMETER_NAME.equals(fieldName) ?
                 BUILDER_SETTER_DEFAULT_PARAMETER_NAME :
                 BUILDER_SETTER_ALTERNATIVE_PARAMETER_NAME;
         final PsiMethod setterMethod = psiElementFactory.createMethod(methodName, builderType);

--- a/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderOption.java
+++ b/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderOption.java
@@ -6,6 +6,7 @@ public enum InnerBuilderOption {
     NEW_BUILDER_METHOD("newBuilderMethod"),
     COPY_CONSTRUCTOR("copyConstructor"),
     WITH_NOTATION("withNotation"),
+    FIELD_NAMES("fieldNames"),
     JSR305_ANNOTATIONS("useJSR305Annotations"),
     FINDBUGS_ANNOTATION("useFindbugsAnnotation"),
     WITH_JAVADOC("withJavadoc");

--- a/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderOptionSelector.java
+++ b/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderOptionSelector.java
@@ -49,6 +49,15 @@ public final class InnerBuilderOptionSelector {
                         .build());
         options.add(
                 SelectorOption.newBuilder()
+                        .withCaption("Use field names in setter")
+                        .withMnemonic('s')
+                        .withToolTip(
+                                "Generate builder methods that has the same parameter names in setter methods as field names, for example: "
+                                        + "builder.withName(String fieldName)")
+                        .withOption(InnerBuilderOption.FIELD_NAMES)
+                        .build());
+        options.add(
+                SelectorOption.newBuilder()
                         .withCaption("Add JSR-305 @Nonnull annotation")
                         .withMnemonic('j')
                         .withToolTip(


### PR DESCRIPTION
To have a better control about the names of the created setter methods in the builders it would be awesome to use the field names as setter parameter names. I created the code for you. Please check it.