### PR TITLE
Add option to add @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")

### DIFF
--- a/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderGenerator.java
+++ b/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderGenerator.java
@@ -298,7 +298,7 @@ public class InnerBuilderGenerator implements Runnable {
             methodName = fieldName;
         }
 
-        final String parameterName = options.contains(InnerBuilderOption.FIELD_NAMES) ? 
+        final String parameterName = options.contains(InnerBuilderOption.FIELD_NAMES) ?
 		fieldName :
 		!BUILDER_SETTER_DEFAULT_PARAMETER_NAME.equals(fieldName) ?
                 BUILDER_SETTER_DEFAULT_PARAMETER_NAME :
@@ -412,6 +412,7 @@ public class InnerBuilderGenerator implements Runnable {
         PsiUtil.setModifierProperty(builderClass, PsiModifier.STATIC, true);
         PsiUtil.setModifierProperty(builderClass, PsiModifier.FINAL, true);
         setBuilderComment(builderClass, targetClass);
+        setBuilderAnnotation(builderClass);
         return builderClass;
     }
 
@@ -477,6 +478,12 @@ public class InnerBuilderGenerator implements Runnable {
             str.append(targetClass.getName()).append("} builder static inner class.\n");
             str.append("*/");
             setStringComment(clazz, str.toString());
+        }
+    }
+
+    private void setBuilderAnnotation(final PsiClass clazz) {
+        if (currentOptions().contains(InnerBuilderOption.PMD_AVOID_FIELD_NAME_MATCHING_METHOD_NAME_ANNOTATION)) {
+            clazz.getModifierList().addAnnotation("SuppressWarnings(\"PMD.AvoidFieldNameMatchingMethodName\")");
         }
     }
 

--- a/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderOption.java
+++ b/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderOption.java
@@ -8,6 +8,7 @@ public enum InnerBuilderOption {
     WITH_NOTATION("withNotation"),
     JSR305_ANNOTATIONS("useJSR305Annotations"),
     FINDBUGS_ANNOTATION("useFindbugsAnnotation"),
+    PMD_AVOID_FIELD_NAME_MATCHING_METHOD_NAME_ANNOTATION("suppressAvoidFieldNameMatchingMethodName"),
     WITH_JAVADOC("withJavadoc"),
     FIELD_NAMES("fieldNames");
 

--- a/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderOptionSelector.java
+++ b/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderOptionSelector.java
@@ -58,6 +58,14 @@ public final class InnerBuilderOptionSelector {
                         .build());
         options.add(
                 SelectorOption.newBuilder()
+                        .withCaption("Add @SuppressWarnings(\"PMD.AvoidFieldNameMatchingMethodName\") annotation")
+                        .withMnemonic('p')
+                        .withToolTip(
+                                "Add @SuppressWarnings(\"PMD.AvoidFieldNameMatchingMethodName\") annotation to the generated Builder class")
+                        .withOption(InnerBuilderOption.PMD_AVOID_FIELD_NAME_MATCHING_METHOD_NAME_ANNOTATION)
+                        .build());
+        options.add(
+                SelectorOption.newBuilder()
                         .withCaption("Add Findbugs @NonNull annotation")
                         .withMnemonic('b')
                         .withToolTip(

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,11 +1,12 @@
 <idea-plugin version="2" url="https://github.com/analytically/innerbuilder">
     <id>InnerBuilder</id>
     <name>InnerBuilder</name>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
 
     <description><![CDATA[${project.description}]]></description>
 
     <change-notes><![CDATA[
+      09.06.2017 - 1.1.4 - Added a new option to add @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName") to the generated builder.<br/>
       04.06.2016 - 1.1.3 - Added a new option to use field name for setters.<br/>
       30.04.2015 - 1.1.2 - Added more options to use JSR-305/Findbugs @Nonnull annotations and generate Javadoc.<br/>
       13.06.2014 - 1.1.1 - Bugfix for final fields in copy builder, thanks to neilg.<br/>


### PR DESCRIPTION
Every time I create a `Builder` I introduce a new [PMD warning](https://pmd.github.io/pmd-5.7.0/pmd-java/rules/java/naming.html#AvoidFieldNameMatchingMethodName). IMHO the rule makes sense, but not in the case of a `Builder`. This PR adds the option to add the appropriate `@SuppressWarnings` annotation to each `Builder`. 