### PR TITLE
New options: builder name includes outer class name, final parameters

### DIFF
--- a/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderOption.java
+++ b/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderOption.java
@@ -11,7 +11,9 @@ public enum InnerBuilderOption {
     FINDBUGS_ANNOTATION("useFindbugsAnnotation"),
     PMD_AVOID_FIELD_NAME_MATCHING_METHOD_NAME_ANNOTATION("suppressAvoidFieldNameMatchingMethodName"),
     WITH_JAVADOC("withJavadoc"),
-    FIELD_NAMES("fieldNames");
+    FIELD_NAMES("fieldNames"),
+    FINAL_PARAMETERS("finalParameters"),
+    BUILDER_NAME_HAS_TARGET_CLASS_NAME("builderTargetClassName");
 
     private final String property;
 

--- a/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderOptionSelector.java
+++ b/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderOptionSelector.java
@@ -90,15 +90,32 @@ public final class InnerBuilderOptionSelector {
                         .withOption(InnerBuilderOption.WITH_JAVADOC)
                         .build());
 
-	options.add(
-		SelectorOption.newBuilder()
-			.withCaption("Use field names in setter")
-			.withMnemonic('s')
-			.withToolTip(
-				"Generate builder methods that has the same parameter names in setter methods as field names, for example: "
-				+ "builder.withName(String fieldName)")
-			.withOption(InnerBuilderOption.FIELD_NAMES)
-			.build());
+        options.add(
+                SelectorOption.newBuilder()
+                        .withCaption("Use field names in setter")
+                        .withMnemonic('s')
+                        .withToolTip(
+                                "Generate builder methods that has the same parameter names in setter methods as field names, for example: "
+                                        + "builder.withName(String fieldName)")
+                        .withOption(InnerBuilderOption.FIELD_NAMES)
+                        .build());
+
+        options.add(
+                SelectorOption.newBuilder()
+                        .withCaption("Use target class name in builder name")
+                        .withMnemonic('e')
+                        .withToolTip(
+                                "Generate builder with name that includes target class name, for example: MyClassBuilder")
+                        .withOption(InnerBuilderOption.BUILDER_NAME_HAS_TARGET_CLASS_NAME)
+                        .build());
+
+        options.add(
+                SelectorOption.newBuilder()
+                        .withCaption("Use final paramters for generated methods")
+                        .withMnemonic('r')
+                        .withToolTip("Parameters are final for all generated methods")
+                        .withOption(InnerBuilderOption.FINAL_PARAMETERS)
+                        .build());
 
         return options;
     }
@@ -164,5 +181,6 @@ public final class InnerBuilderOptionSelector {
         });
         return optionCheckBox;
     }
+
 }
 


### PR DESCRIPTION
I have added two options. When selected, these do the following:

- BUILDER_NAME_HAS_TARGET_CLASS_NAME: the class name of the builder will include the outer class. So if the inner builder is created in a class 'MyClass', the builder will be named 'MyClassBuilder'.

- FINAL_PARAMETERS: all method parameters (setters, constructor new and copy methods) will be final.

If the options are not selected, the functionality remains unchanged.  