### PR TITLE
ISSUE #65: do not generate empty public constructor for builders

### DIFF
--- a/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderGenerator.java
+++ b/src/main/java/org/jetbrains/plugins/innerbuilder/InnerBuilderGenerator.java
@@ -108,8 +108,10 @@ public class InnerBuilderGenerator implements Runnable {
         }
 
         // builder constructor, accepting the final fields
-        final PsiMethod builderConstructorMethod = generateBuilderConstructor(builderClass, finalFields, options);
-        addMethod(builderClass, null, builderConstructorMethod, false);
+        if(finalFields.size() == 0 && !options.contains(InnerBuilderOption.NEW_BUILDER_METHOD)) {
+            final PsiMethod builderConstructorMethod = generateBuilderConstructor(builderClass, finalFields, options);
+            addMethod(builderClass, null, builderConstructorMethod, false);
+        }
 
         // builder copy constructor or static copy method
         if (options.contains(InnerBuilderOption.COPY_CONSTRUCTOR)) {


### PR DESCRIPTION
This PR solves issue #65 by not generating the constructor method when there are no constructor parameters and when the constructor should not be private (i.e. when no static newBuilder method is generated).

I have not made this behaviour configurable at the moment because empty public constructors are always equivalent to the default constructor (so backwards compatibility should not be an issue) but if you'd prefer it to be a configurable option I could change that.

An alternative implementation would also be to generate the constructor method but skip adding it to the Builder Class when it's public and has no parameters. This is a little more future-proof (e.g. there's a change in the logic that determines the visibility of the constuctor) but it does lead to an unnecessary call to `generateBuilderConstructor`